### PR TITLE
Update README with recent semantic correspondence papers (2025-2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,26 @@ Thank you!
 - *Shape-of-You: Fused Gromov-Wasserstein Optimal Transport for
 Semantic Correspondence in-the-Wild*  
   Jiin Im, Sisung Liu, Je Hyeong Hong  
-  **CVPR 2026**
+  **CVPR 2026**.
   [[Paper]](https://arxiv.org/pdf/2603.11618)
   [[Code]](https://github.com/SpatialAILab/shapeofyou)
   
 - *SimpleMatch: A Simple and Strong Baseline for Semantic Correspondence*  
   Hailong Jin, Huiying Li  
-  **arxiv preprint 2026**
+  **arxiv preprint 2026**.
   [[Paper]](https://arxiv.org/pdf/2601.12357)
   [[Code]](https://github.com/hailong23-jin/SimpleMatch)
 
 ## 2025
 - *Gromov Wasserstein Optimal Transport for Semantic Correspondences*  
   Francis Snelgar, Stephen Gould, Ming Xu, Liang Zheng, Akshay Asthana  
-  **BMVC 2025**
+  **BMVC 2025**.
   [[Paper]](https://arxiv.org/pdf/2602.03105)
   [[Code]](https://github.com/fsnelgar/semantic_matching_gwot)
 
 - *Similarity-Aware Selective State-Space Modeling for Semantic Correspondence*  
   Seungwook Kim, Minsu Cho  
-  **ICCV 2025 Findings Oral**
+  **ICCV 2025 Findings Oral**.
   [[Paper]](https://arxiv.org/pdf/2509.24318)
   [[Code]](https://github.com/wookiekim/MambaMatcher)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Finally, please check out our TPAMI 2025 paper ["Semantic Correspondence: Unifie
 Thank you!
 
 ## 📚 Contents
+- [2026](#2026)
 - [2025](#2025)
 - [2024](#2024)
 - [2023](#2023)
@@ -19,8 +20,33 @@ Thank you!
 - [2017](#2017)
 - [--2016](#--2016)
 
+## 2026
+- *Shape-of-You: Fused Gromov-Wasserstein Optimal Transport for
+Semantic Correspondence in-the-Wild*  
+  Jiin Im, Sisung Liu, Je Hyeong Hong  
+  **CVPR 2026**
+  [[Paper]](https://arxiv.org/pdf/2603.11618)
+  [[Code]](https://github.com/SpatialAILab/shapeofyou)
+  
+- *SimpleMatch: A Simple and Strong Baseline for Semantic Correspondence*  
+  Hailong Jin, Huiying Li  
+  **arxiv preprint 2026**
+  [[Paper]](https://arxiv.org/pdf/2601.12357)
+  [[Code]](https://github.com/hailong23-jin/SimpleMatch)
 
 ## 2025
+- *Gromov Wasserstein Optimal Transport for Semantic Correspondences*  
+  Francis Snelgar, Stephen Gould, Ming Xu, Liang Zheng, Akshay Asthana  
+  **BMVC 2025**
+  [[Paper]](https://arxiv.org/pdf/2602.03105)
+  [[Code]](https://github.com/fsnelgar/semantic_matching_gwot)
+
+- *Similarity-Aware Selective State-Space Modeling for Semantic Correspondence*  
+  Seungwook Kim, Minsu Cho  
+  **ICCV 2025 Findings Oral**
+  [[Paper]](https://arxiv.org/pdf/2509.24318)
+  [[Code]](https://github.com/wookiekim/MambaMatcher)
+
 - *Semantic Correspondence: Unified Benchmarking and a Strong Baseline*  
   Kaiyan Zhang, Xinghui Li, Jingyi Lu, Kai Han  
   **TPAMI 2025**. 
@@ -31,7 +57,13 @@ Thank you!
 - *Jamais Vu: Exposing the Generalization Gap in Supervised Semantic Correspondence*  
   Octave Mariotti, Zhipeng Du, Yash Bhalgat, Oisin Mac Aodha, Hakan Bilen  
   **NeurIPS 2025**. 
-  [[Paper]](https://arxiv.org/abs/2506.08220) 
+  [[Paper]](https://arxiv.org/abs/2506.08220)
+
+- *Unleashing Diffusion Transformers for Visual Correspondence by Modulating Massive Activations*  
+  Chaofan Gan, Yuanpeng Tu, Xi Chen, Tieyuan Chen, Yuxi Li, Mehrtash Harandi, Weiyao Lin  
+  **NeurIPS 2025**. 
+  [[Paper]](https://arxiv.org/abs/2505.18584)
+  [[Code]](https://github.com/ganchaofan0000/DiTF)
 
 - *Do It Yourself: Learning Semantic Correspondence from Pseudo-Labels*   
   Olaf Dünkel, Thomas Wimmer, Christian Theobalt, Christian Rupprecht, Adam Kortylewski  
@@ -72,10 +104,6 @@ Thank you!
   **arXiv preprint 2025**. 
   [[Paper]](https://arxiv.org/abs/2508.00272)  
 
-- *Unleashing Diffusion Transformers for Visual Correspondence by Modulating Massive Activations*  
-  Chaofan Gan, Yuanpeng Tu, Xi Chen, Tieyuan Chen, Yuxi Li, Mehrtash Harandi, Weiyao Lin  
-  **arXiv preprint 2025**. 
-  [[Paper]](https://arxiv.org/abs/2505.18584)  
 
 ## 2024
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,26 @@ Thank you!
 - [--2016](#--2016)
 
 ## 2026
+
+- *Geometry Matters: 3D Foundation Priors for Learning Semantic Correspondence*  
+  Artur Jesslen, Olaf Dünkel, Adam Kortylewski  
+  **arxiv preprint**.
+  [[Paper]](https://arxiv.org/abs/2605.30093)
+  [[Code]](https://github.com/GenIntel/3D-SC)
+
+- *MARCO: Navigating the Unseen Space of Semantic Correspondence*  
+  Claudia Cuttano, Gabriele Trivigno, Carlo Masone, Stefan Roth  
+  **CVPR 2026 Oral**.
+  [[Paper]](https://arxiv.org/pdf/2604.18267)
+  [[Project Page]](https://visinf.github.io/MARCO/)
+  [[Code]](https://github.com/visinf/MARCO)
+
 - *Shape-of-You: Fused Gromov-Wasserstein Optimal Transport for
 Semantic Correspondence in-the-Wild*  
   Jiin Im, Sisung Liu, Je Hyeong Hong  
   **CVPR 2026**.
   [[Paper]](https://arxiv.org/pdf/2603.11618)
   [[Code]](https://github.com/SpatialAILab/shapeofyou)
-  
-- *SimpleMatch: A Simple and Strong Baseline for Semantic Correspondence*  
-  Hailong Jin, Huiying Li  
-  **arxiv preprint 2026**.
-  [[Paper]](https://arxiv.org/pdf/2601.12357)
-  [[Code]](https://github.com/hailong23-jin/SimpleMatch)
 
 ## 2025
 - *Gromov Wasserstein Optimal Transport for Semantic Correspondences*  


### PR DESCRIPTION
Hi! Thank you for maintaining this awesome repository. 

I've added several recent papers to keep the list up to date and fixed some minor formatting issues. Here is the summary of the changes:

- **Added `2026` section:** Included recent papers such as MARCO (CVPR 2026 Oral), Shape-of-You (CVPR 2026), and Geometry Matters.
- **Updated `2025` section:** Added new papers from BMVC 2025 and ICCV 2025.
- **Minor Fixes:** Fixed punctuation and updated some conference details for existing papers.

Please review the changes and let me know if anything needs to be modified. Thanks!